### PR TITLE
Add workflow for publishing npm package

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -1,0 +1,27 @@
+name: Publish Package Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish_package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@michaelfdickey'
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,15 @@
   "description": "A simple test package for GitHub Actions workflow trigger",
   "main": "index.js",
   "scripts": {
-    "publish": "npm publish"
+    "publish": "npm publish",
+    "publish:github": "npm publish --registry https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/michaelfdickey/package-publish-test.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
This pull request introduces enhancements to the npm package publishing process and updates the GitHub Actions workflow for a more streamlined package deployment to the GitHub package registry.

- **Updates `package.json`**: 
  - Adds a new script `publish:github` for publishing the package to the GitHub package registry.
  - Specifies the repository field with type and URL to ensure proper linking and identification of the source code repository.
  - Includes `publishConfig` with access level set to public, allowing the package to be published publicly on the GitHub package registry.

- **Adds a new GitHub Actions workflow (`publish_package.yml`)**:
  - Triggers on push to the main branch, automating the publishing process upon new commits.
  - Configures the workflow to run on `ubuntu-latest` and sets up Node.js environment with version 14.
  - Utilizes steps for checking out code, setting up Node.js with registry URL and scope, installing dependencies, building the package, and publishing it to the GitHub package registry using the `NODE_AUTH_TOKEN`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/package-publish-test?shareId=5e4f34e9-5b70-4e33-8131-34da4d0ad82c).