### PR TITLE
Add missing build script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "publish": "npm publish",
-    "publish:github": "npm publish --registry https://npm.pkg.github.com"
+    "publish:github": "npm publish --registry https://npm.pkg.github.com",
+    "build": "echo 'Build script placeholder'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a build script to the `package.json` to fix the 'missing script: build' error in the publish package action workflow.
- Adds a placeholder for the `build` script in the `scripts` section of `package.json`, ensuring the workflow can complete without errors.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/package-publish-test?shareId=a92632c2-591f-4301-8cd1-e158f2b3224c).