### PR TITLE
Add workflow for publishing Ruby gems

### DIFF
--- a/.github/workflows/publish_rubygem.yml
+++ b/.github/workflows/publish_rubygem.yml
@@ -1,0 +1,25 @@
+name: Publish RubyGem Workflow
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  publish_rubygem:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+      - name: Build Gem
+        run: gem build *.gemspec
+      - name: Publish to RubyGems
+        run: gem push *.gem
+        env:
+          RUBYGEMS_AUTH_TOKEN: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
+      - name: Publish to GitHub Package Registry
+        run: gem push *.gem --host https://rubygems.pkg.github.com/${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/gemspec/package-publish-test.gemspec
+++ b/gemspec/package-publish-test.gemspec
@@ -1,0 +1,23 @@
+Gem::Specification.new do |spec|
+  spec.name          = "package-publish-test"
+  spec.version       = "0.1.0"
+  spec.authors       = ["Michael Dickey"]
+  spec.email         = ["michael@dickey.xxx"]
+
+  spec.summary       = %q{A simple test package for RubyGems and GitHub Package Registry}
+  spec.description   = %q{This package is a test for publishing to RubyGems and GitHub Package Registry using GitHub Actions.}
+  spec.homepage      = "https://github.com/michaelfdickey/package-publish-test"
+  spec.license       = "MIT"
+
+  spec.files         = Dir["lib/**/*.rb", "bin/*", "gemspec/*.gemspec"]
+  spec.bindir        = "bin"
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.required_ruby_version = ">= 2.6"
+
+  spec.metadata = {
+    "source_code_uri" => spec.homepage,
+    "changelog_uri"   => "#{spec.homepage}/CHANGELOG.md"
+  }
+end


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow and a gem specification file to enable publishing a simple test package to both RubyGems and the GitHub Package Registry, without affecting the existing npm workflows and package files.

- **Adds a new GitHub Actions workflow file** `.github/workflows/publish_rubygem.yml` that:
  - Triggers on `workflow_dispatch` for manual execution.
  - Sets up Ruby environment, builds the gem, and publishes it to RubyGems and GitHub Package Registry.
- **Introduces a gem specification file** `gemspec/package-publish-test.gemspec` that:
  - Specifies the gem's metadata, including name, version, authors, and required Ruby version.
  - Defines files to be included in the gem, executable files, and the required Ruby version for compatibility.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/package-publish-test?shareId=0d66aa98-1c59-4734-8aa8-ebe675f82466).