### PR TITLE
Update Ruby setup in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish_rubygem.yml
+++ b/.github/workflows/publish_rubygem.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
       - name: Build Gem


### PR DESCRIPTION
Updates the Ruby setup step in the `.github/workflows/publish_rubygem.yml` to use `ruby/setup-ruby@v1` instead of the deprecated `actions/setup-ruby@v1`.

- Changes the action used for setting up Ruby from `actions/setup-ruby@v1` to `ruby/setup-ruby@v1`.
- Retains the specified Ruby version as '2.7' in the workflow configuration.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/package-publish-test?shareId=52954bd0-3178-4579-9be2-0b9da0ab8ba4).