### PR TITLE
Fix gemspec file path in RubyGem publish workflow

### DIFF
--- a/.github/workflows/publish_rubygem.yml
+++ b/.github/workflows/publish_rubygem.yml
@@ -14,12 +14,12 @@ jobs:
         with:
           ruby-version: '2.7'
       - name: Build Gem
-        run: gem build *.gemspec
+        run: gem build gemspec/package-publish-test.gemspec
       - name: Publish to RubyGems
-        run: gem push *.gem
+        run: gem push package-publish-test-*.gem
         env:
           RUBYGEMS_AUTH_TOKEN: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
       - name: Publish to GitHub Package Registry
-        run: gem push *.gem --host https://rubygems.pkg.github.com/${{ github.repository }}
+        run: gem push package-publish-test-*.gem --host https://rubygems.pkg.github.com/${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Fixes the gem build and push commands in the GitHub Actions workflow to correctly reference the gemspec file and built gem file.

- Updates the `gem build` command to use the specific gemspec file `gemspec/package-publish-test.gemspec` instead of a wildcard, preventing the 'Gemspec file not found' error.
- Modifies the `gem push` commands to target the built gem file using a more precise pattern `package-publish-test-*.gem`, ensuring the correct file is pushed to RubyGems and GitHub Package Registry.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/package-publish-test?shareId=3295c2f8-1cef-42ea-b4f1-6a0e2b7f9377).